### PR TITLE
Use Versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
           path: packages
       - name: Push packages
         run: dotnet nuget push "packages/*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
-      - uses: dotnet/nbgv@v0.4.0
+      - uses: dotnet/nbgv@v0.4.1
         id: nbgv
       - name: Create GitHub release
         uses: softprops/action-gh-release@v1

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,12 +10,15 @@
         <Authors>Alamo Engine Tools and Contributors</Authors>
         <Copyright>Copyright © 2023 Alamo Engine Tools and contributors. All rights reserved.</Copyright>
         <PackageProjectUrl>https://github.com/AlamoEngine-Tools/PetroglyphTools</PackageProjectUrl>
-        <PackageLicenseUrl>https://github.com/AlamoEngine-Tools/PetroglyphTools/blob/master/LICENSE</PackageLicenseUrl>
+		<LicenseFile>$(MSBuildThisFileDirectory)LICENSE</LicenseFile>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
         <RepositoryUrl>https://github.com/AlamoEngine-Tools/PetroglyphTools</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <Company>Alamo Engine Tools</Company>
         <PackageReadmeFile>README.md</PackageReadmeFile>
-    </PropertyGroup>
+	    <PackageIcon>aet.png</PackageIcon>
+    
+</PropertyGroup>
     <PropertyGroup>
         <LangVersion>latest</LangVersion>
         <ImplicitUsings>disable</ImplicitUsings>
@@ -34,4 +37,9 @@
         </PackageReference>
         <None Include="$(MSBuildThisFileDirectory)README.md" Pack="true" PackagePath=""/>
     </ItemGroup>
+
+	<ItemGroup Condition="'$(IsPackable)' == 'true'">
+		<None Include="$(LicenseFile)" Pack="true" PackagePath=""/>
+		<None Include="$(MSBuildThisFileDirectory)aet.png" Pack="true" PackagePath=""/>
+	</ItemGroup>
 </Project>

--- a/PG.Benchmarks/PG.Benchmarks.csproj
+++ b/PG.Benchmarks/PG.Benchmarks.csproj
@@ -6,12 +6,8 @@
 		<Product>PG.Benchmarks</Product>
 		<Title>PG.Benchmarks</Title>
 		<PackageId>AlamoEngineTools.PG.Benchmarks</PackageId>
-		<PackageLicenseUrl>https://github.com/AlamoEngine-Tools/PetroglyphTools/blob/main/LICENSE</PackageLicenseUrl>
 		<PackageTags>alamo,petroglyph,glyphx</PackageTags>
-		<AssemblyVersion>0.1.0-alpha.1</AssemblyVersion>
-		<FileVersion>0.1.0-alpha.1</FileVersion>
 		<NeutralLanguage>en</NeutralLanguage>
-		<Version>0.1.0-alpha.1</Version>
 		<PackageIcon>aet.png</PackageIcon>
 	</PropertyGroup>
 

--- a/PG.Benchmarks/PG.Benchmarks.csproj
+++ b/PG.Benchmarks/PG.Benchmarks.csproj
@@ -8,7 +8,6 @@
 		<PackageId>AlamoEngineTools.PG.Benchmarks</PackageId>
 		<PackageTags>alamo,petroglyph,glyphx</PackageTags>
 		<NeutralLanguage>en</NeutralLanguage>
-		<PackageIcon>aet.png</PackageIcon>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/PG.Commons/PG.Commons.Test/PG.Commons.Test.csproj
+++ b/PG.Commons/PG.Commons.Test/PG.Commons.Test.csproj
@@ -4,8 +4,7 @@
         <TargetFrameworks>net7.0</TargetFrameworks>
         <TargetFrameworks Condition="!$([MSBuild]::IsOsUnixLike())">$(TargetFrameworks);net48</TargetFrameworks>
         <PackageId>AlamoEngineTools.PG.Commons.Test</PackageId>
-	    <PackageIcon>aet.png</PackageIcon>
-        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+	    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="coverlet.msbuild" Version="6.0.0">
@@ -26,11 +25,5 @@
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\PG.Commons\PG.Commons.csproj" />
-    </ItemGroup>
-    <ItemGroup>
-      <None Update="aet.png">
-        <Pack>True</Pack>
-        <PackagePath></PackagePath>
-      </None>
     </ItemGroup>
 </Project>

--- a/PG.Commons/PG.Commons.Test/PG.Commons.Test.csproj
+++ b/PG.Commons/PG.Commons.Test/PG.Commons.Test.csproj
@@ -4,10 +4,7 @@
         <TargetFrameworks>net7.0</TargetFrameworks>
         <TargetFrameworks Condition="!$([MSBuild]::IsOsUnixLike())">$(TargetFrameworks);net48</TargetFrameworks>
         <PackageId>AlamoEngineTools.PG.Commons.Test</PackageId>
-        <Version>0.1.0-alpha.1</Version>
-        <AssemblyVersion>0.1.0-alpha.1</AssemblyVersion>
-        <FileVersion>0.1.0-alpha.1</FileVersion>
-        <PackageIcon>aet.png</PackageIcon>
+	    <PackageIcon>aet.png</PackageIcon>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
     <ItemGroup>

--- a/PG.Commons/PG.Commons/PG.Commons.csproj
+++ b/PG.Commons/PG.Commons/PG.Commons.csproj
@@ -6,7 +6,6 @@
         <PackageId>AlamoEngineTools.PG.Commons</PackageId>
 	    <PackageTags>alamo,petroglyph,glyphx</PackageTags>
 	    <NeutralLanguage>en</NeutralLanguage>
-	    <PackageIcon>aet.png</PackageIcon>
     </PropertyGroup>
     <PropertyGroup>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -32,11 +31,5 @@
         <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
         <PackageReference Include="System.IO.Abstractions" Version="19.2.51" />
         <PackageReference Include="System.IO.Hashing" Version="7.0.0" />
-    </ItemGroup>
-    <ItemGroup>
-        <None Update="aet.png">
-            <Pack>True</Pack>
-            <PackagePath></PackagePath>
-        </None>
     </ItemGroup>
 </Project>

--- a/PG.Commons/PG.Commons/PG.Commons.csproj
+++ b/PG.Commons/PG.Commons/PG.Commons.csproj
@@ -4,13 +4,9 @@
         <Product>PG.Commons</Product>
         <Title>PG.Commons</Title>
         <PackageId>AlamoEngineTools.PG.Commons</PackageId>
-        <PackageLicenseUrl>https://github.com/AlamoEngine-Tools/PetroglyphTools/blob/main/LICENSE</PackageLicenseUrl>
-        <PackageTags>alamo,petroglyph,glyphx</PackageTags>
-        <AssemblyVersion>0.1.0-alpha.1</AssemblyVersion>
-        <FileVersion>0.1.0-alpha.1</FileVersion>
-        <NeutralLanguage>en</NeutralLanguage>
-        <Version>0.1.0-alpha.1</Version>
-        <PackageIcon>aet.png</PackageIcon>
+	    <PackageTags>alamo,petroglyph,glyphx</PackageTags>
+	    <NeutralLanguage>en</NeutralLanguage>
+	    <PackageIcon>aet.png</PackageIcon>
     </PropertyGroup>
     <PropertyGroup>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/PG.StarWarsGame.Files.DAT/PG.StarWarsGame.Files.DAT.Test/PG.StarWarsGame.Files.DAT.Test.csproj
+++ b/PG.StarWarsGame.Files.DAT/PG.StarWarsGame.Files.DAT.Test/PG.StarWarsGame.Files.DAT.Test.csproj
@@ -3,7 +3,6 @@
         <IsPackable>false</IsPackable>
         <TargetFrameworks>net7.0</TargetFrameworks>
         <TargetFrameworks Condition="!$([MSBuild]::IsOsUnixLike())">$(TargetFrameworks);net48</TargetFrameworks>
-        <PackageIcon>aet.png</PackageIcon>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="coverlet.msbuild" Version="6.0.0">
@@ -26,11 +25,5 @@
         <ProjectReference Include="..\..\PG.Commons\PG.Commons.Test\PG.Commons.Test.csproj" />
         <ProjectReference Include="..\..\PG.Testing\PG.Testing.csproj" />
         <ProjectReference Include="..\PG.StarWarsGame.Files.DAT\PG.StarWarsGame.Files.DAT.csproj" />
-    </ItemGroup>
-    <ItemGroup>
-      <None Update="aet.png">
-        <Pack>True</Pack>
-        <PackagePath></PackagePath>
-      </None>
     </ItemGroup>
 </Project>

--- a/PG.StarWarsGame.Files.DAT/PG.StarWarsGame.Files.DAT/PG.StarWarsGame.Files.DAT.csproj
+++ b/PG.StarWarsGame.Files.DAT/PG.StarWarsGame.Files.DAT/PG.StarWarsGame.Files.DAT.csproj
@@ -4,12 +4,7 @@
         <Title>PG.StarWarsGame.Files.DAT</Title>
         <Product>PG.StarWarsGame.Files.DAT</Product>
         <PackageId>AlamoEngineTools.PG.StarWarsGame.Files.DAT</PackageId>
-        <Version>0.1.0-alpha.1</Version>
-        <PackageLicenseUrl>https://github.com/AlamoEngine-Tools/PetroglyphTools/blob/main/LICENSE</PackageLicenseUrl>
-        <PackageIcon>aet.png</PackageIcon>
-        <PackageTags>alamo,petroglyph,glyphx</PackageTags>
-        <AssemblyVersion>0.1.0-alpha.1</AssemblyVersion>
-        <FileVersion>0.1.0-alpha.1</FileVersion>
+	    <PackageTags>alamo,petroglyph,glyphx</PackageTags>
     </PropertyGroup>
     <PropertyGroup>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/PG.StarWarsGame.Files.MEG/PG.StarWarsGame.Files.MEG.Test/PG.StarWarsGame.Files.MEG.Test.csproj
+++ b/PG.StarWarsGame.Files.MEG/PG.StarWarsGame.Files.MEG.Test/PG.StarWarsGame.Files.MEG.Test.csproj
@@ -4,7 +4,6 @@
         <TargetFrameworks>net7.0</TargetFrameworks>
         <TargetFrameworks Condition="!$([MSBuild]::IsOsUnixLike())">$(TargetFrameworks);net48</TargetFrameworks>
         <PackageId>AlamoEngineTools.PG.StarWarsGame.Files.MEG.Test</PackageId>
-	    <PackageIcon>aet.png</PackageIcon>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="coverlet.msbuild" Version="6.0.0">
@@ -26,11 +25,5 @@
         <ProjectReference Include="..\..\PG.Commons\PG.Commons.Test\PG.Commons.Test.csproj" />
         <ProjectReference Include="..\..\PG.Testing\PG.Testing.csproj" />
         <ProjectReference Include="..\PG.StarWarsGame.Files.MEG\PG.StarWarsGame.Files.MEG.csproj" />
-    </ItemGroup>
-    <ItemGroup>
-      <None Update="aet.png">
-        <Pack>True</Pack>
-        <PackagePath></PackagePath>
-      </None>
     </ItemGroup>
 </Project>

--- a/PG.StarWarsGame.Files.MEG/PG.StarWarsGame.Files.MEG.Test/PG.StarWarsGame.Files.MEG.Test.csproj
+++ b/PG.StarWarsGame.Files.MEG/PG.StarWarsGame.Files.MEG.Test/PG.StarWarsGame.Files.MEG.Test.csproj
@@ -4,10 +4,7 @@
         <TargetFrameworks>net7.0</TargetFrameworks>
         <TargetFrameworks Condition="!$([MSBuild]::IsOsUnixLike())">$(TargetFrameworks);net48</TargetFrameworks>
         <PackageId>AlamoEngineTools.PG.StarWarsGame.Files.MEG.Test</PackageId>
-        <Version>0.1.0-alpha.1</Version>
-        <AssemblyVersion>0.1.0-alpha.1</AssemblyVersion>
-        <FileVersion>0.1.0-alpha.1</FileVersion>
-        <PackageIcon>aet.png</PackageIcon>
+	    <PackageIcon>aet.png</PackageIcon>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="coverlet.msbuild" Version="6.0.0">

--- a/PG.StarWarsGame.Files.MEG/PG.StarWarsGame.Files.MEG/PG.StarWarsGame.Files.MEG.csproj
+++ b/PG.StarWarsGame.Files.MEG/PG.StarWarsGame.Files.MEG/PG.StarWarsGame.Files.MEG.csproj
@@ -4,7 +4,6 @@
         <Title>PG.StarWarsGame.Files.MEG</Title>
         <PackageId>AlamoEngineTools.PG.StarWarsGame.Files.MEG</PackageId>
         <Product>PG.StarWarsGame.Files.MEG</Product>
-	    <PackageIcon>aet.png</PackageIcon>
     </PropertyGroup>
     <PropertyGroup>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -32,11 +31,5 @@
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\..\PG.Commons\PG.Commons\PG.Commons.csproj" />
-    </ItemGroup>
-    <ItemGroup>
-      <None Update="aet.png">
-        <Pack>True</Pack>
-        <PackagePath></PackagePath>
-      </None>
     </ItemGroup>
 </Project>

--- a/PG.StarWarsGame.Files.MEG/PG.StarWarsGame.Files.MEG/PG.StarWarsGame.Files.MEG.csproj
+++ b/PG.StarWarsGame.Files.MEG/PG.StarWarsGame.Files.MEG/PG.StarWarsGame.Files.MEG.csproj
@@ -4,10 +4,7 @@
         <Title>PG.StarWarsGame.Files.MEG</Title>
         <PackageId>AlamoEngineTools.PG.StarWarsGame.Files.MEG</PackageId>
         <Product>PG.StarWarsGame.Files.MEG</Product>
-        <Version>0.1.0-alpha.1</Version>
-        <AssemblyVersion>0.1.0-alpha.1</AssemblyVersion>
-        <FileVersion>0.1.0-alpha.1</FileVersion>
-        <PackageIcon>aet.png</PackageIcon>
+	    <PackageIcon>aet.png</PackageIcon>
     </PropertyGroup>
     <PropertyGroup>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/PG.StarWarsGame.Files.MTD/PG.StarWarsGame.Files.MTD/PG.StarWarsGame.Files.MTD.csproj
+++ b/PG.StarWarsGame.Files.MTD/PG.StarWarsGame.Files.MTD/PG.StarWarsGame.Files.MTD.csproj
@@ -4,9 +4,6 @@
         <Title>PG.StarWarsGame.Files.MTD</Title>
         <PackageId>AlamoEngineTools.PG.StarWarsGame.Files.MTD</PackageId>
         <Product>PG.StarWarsGame.Files.MTD</Product>
-        <Version>0.1.0-alpha.1</Version>
-        <AssemblyVersion>0.1.0-alpha.1</AssemblyVersion>
-        <FileVersion>0.1.0-alpha.1</FileVersion>
     </PropertyGroup>
     <PropertyGroup>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/PG.StarWarsGame.Files.Xml/PG.StarWarsGame.Files.Xml/PG.StarWarsGame.Files.Xml.csproj
+++ b/PG.StarWarsGame.Files.Xml/PG.StarWarsGame.Files.Xml/PG.StarWarsGame.Files.Xml.csproj
@@ -4,9 +4,6 @@
         <Title>PG.StarWarsGame.Files.Xml</Title>
         <PackageId>AlamoEngineTools.PG.StarWarsGame.Files.Xml</PackageId>
         <Product>PG.StarWarsGame.Files.Xml</Product>
-        <Version>0.1.0-alpha.1</Version>
-        <AssemblyVersion>0.1.0-alpha.1</AssemblyVersion>
-        <FileVersion>0.1.0-alpha.1</FileVersion>
     </PropertyGroup>
     <PropertyGroup>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/PG.Testing/PG.Testing.csproj
+++ b/PG.Testing/PG.Testing.csproj
@@ -4,9 +4,6 @@
         <TargetFrameworks>net7.0</TargetFrameworks>
         <TargetFrameworks Condition="!$([MSBuild]::IsOsUnixLike())">$(TargetFrameworks);net48</TargetFrameworks>
         <PackageId>AlamoEngineTools.PG.Testing</PackageId>
-        <Version>0.1.0-alpha.1</Version>
-        <AssemblyVersion>0.1.0-alpha.1</AssemblyVersion>
-        <FileVersion>0.1.0-alpha.1</FileVersion>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0"/>

--- a/version.json
+++ b/version.json
@@ -1,11 +1,11 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "2.0",
+    "version": "2.0-alpha",
     "assemblyVersion": {
         "precision": "major"
     },
     "publicReleaseRefSpec": [
-        "^refs/heads/main$"
+        "^refs/heads/master"
     ],
     "cloudBuild": {
         "buildNumber": {


### PR DESCRIPTION
The way how it works: 

New releases get deployed when pushed to `master`. The version that is uses is specified in `version.json`. 

Currently is says: `"version": "2.0-alpha"` meaning, we have a *alpha* release build with version `2.0.x` where `x` is auto-incremented by commits on the release branch. 

Changing a Major or Minor version or making a release beta or stable, requires manual changes to `version.json`. 

The following .NET attribtues get set to an assembly: 
`AssemblyFileVersion` **2.0.x.revision**, where revision is auto generated
`AssemblyInformationalVersion` **2.0.x-alpha**
`AssemblyVersion` **2.0.0.0** currently configured to only update the major version (this is common in .NET)
`Version` **2.0.x-alpha** as the **PackageVersion**


On successful deployment a git tag and github release will be created